### PR TITLE
Replace seq_id+VDJ with seq_id+sample_id as fasta identifier

### DIFF
--- a/Proteomics_analysis/translation/AIRRtab_to_fasta.py
+++ b/Proteomics_analysis/translation/AIRRtab_to_fasta.py
@@ -11,19 +11,21 @@ parser.add_argument("-o", "--outname", type=str, default="sequences.fasta", help
 
 args = parser.parse_args()
 
-tab = pd.read_csv(args.input, sep="\t")
-tab["fasta_desc"] = str(tab["v_call"]) + " " + str(tab["d_call"]) + " " + str(tab["j_call"])
+tab = pd.read_csv(args.input, sep="\t", low_memory=False)
+tab['unique_sequence_id'] = tab.apply(lambda x: f'{x["sequence_id"]}_{x["sample_id"]}', axis=1)
+
+# check that unique_sequence_id is really unique
+assert len(tab) == len(tab['unique_sequence_id'].unique())
 
 out_file = args.outname
-ids = tab["sequence_id"]
-descriptions = tab["fasta_desc"]
+ids = tab["unique_sequence_id"]
 seqs = tab["sequence"]
 with open(args.outname, 'wt') as out_handle:
-    for (ii, desc, seq) in zip(ids, descriptions, seqs):
+    for (ii, seq) in zip(ids, seqs):
         record = SeqRecord(
             Seq(seq),
             id=ii,
             name=ii,
-            description=str(desc),
+            description='',
         )
         SeqIO.write(record, out_handle, "fasta")

--- a/Proteomics_analysis/translation/igblast_to_fasta.py
+++ b/Proteomics_analysis/translation/igblast_to_fasta.py
@@ -11,18 +11,18 @@ parser.add_argument("-o", "--outname", type=str, default="sequences_aa.fasta", h
 args = parser.parse_args()
 
 tab = pd.read_csv(args.input, sep="\t")
-tab["fasta_desc"] = tab["v_call"] + " " + tab["d_call"] + " " + tab["j_call"]
 
 out_file = args.outname
 ids = tab["sequence_id"]
-descriptions = tab["fasta_desc"]
 seqs_nt = tab["sequence"]
 seqs_aligned_aa = tab["sequence_alignment_aa"]
 
 with open(args.outname, 'wt') as out_handle:
-    for (ii, desc, seq_nt, seq_al_aa) in zip(ids, descriptions, seqs_nt, seqs_aligned_aa):
+    for (ii, seq_nt, seq_al_aa) in zip(ids, seqs_nt, seqs_aligned_aa):
 
         seq_orig_nt = Seq(seq_nt)
+
+        # Unclear why we trust the manual translations more than the ones from IgBLAST
 
         # Translating sequence
         seq_translated = seq_orig_nt.translate()
@@ -41,6 +41,6 @@ with open(args.outname, 'wt') as out_handle:
             seq_translated,
             id = ii,
             name = ii,
-            description = str(desc),
+            description = '',
         )
         SeqIO.write(record, out_handle, "fasta")


### PR DESCRIPTION
This PR changes the sequence identifiers of the fasta files, which are used for translating BCR sequences.
The sequence IDs need to be unique s.t. the sequences can later on be mapped back to the airrflow output table.
So far, sequence ids were constructed with seq_id+VDJ genes. These identifiers are not always unique and can contain nan values due to an undefined D segment.
Combining `sequence_id` and `sample_id` makes the identifiers unique.